### PR TITLE
Moving carry distance display and miscellaneous cleanup

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,27 +1,16 @@
-import React from "react";
 import { Canvas, useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 import GolfBall from "./components/GolfBall";
-import {
-  useBallPosition,
-  useSimulationActions,
-} from "./stores/SimulationStore";
-import useUnitHelper from "./hooks/useUnitHelper";
-import { MeasurementTypes } from "./utils/units";
+import { useSimulationActions } from "./stores/SimulationStore";
 import { useTheme } from "./stores/PreferencesStore";
-import { ActionIcon, Box, MantineProvider, Text } from "@mantine/core";
+import { Box, MantineProvider } from "@mantine/core";
 import LaunchControls from "./components/LaunchControls";
-import { stylesWithThemedBackgroundColor } from "./utils/styles";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faGear } from "@fortawesome/free-solid-svg-icons";
-import SettingsDialog from "./components/SettingsDialog";
 import Overlay from "./components/Overlay";
 import CarryTracker from "./components/CarryTracker";
+import SettingsControls from "./components/SettingsControls";
 
 export default function App() {
   const theme = useTheme();
-
-  const [showSettings, setShowSettings] = React.useState(false);
 
   return (
     <MantineProvider
@@ -33,26 +22,7 @@ export default function App() {
         <Overlay
           topLeft={<LaunchControls />}
           topCenter={<CarryTracker />}
-          topRight={
-            <Box
-              display="flex"
-              sx={{
-                flexDirection: "column",
-                alignItems: "flex-end",
-              }}
-            >
-              <ActionIcon
-                variant="transparent"
-                color="blue.4"
-                onClick={() => setShowSettings(!showSettings)}
-              >
-                <FontAwesomeIcon icon={faGear} />
-              </ActionIcon>
-              {showSettings && (
-                <SettingsDialog onClose={() => setShowSettings(false)} />
-              )}
-            </Box>
-          }
+          topRight={<SettingsControls />}
         >
           <Canvas camera={{ position: [0, 0, 50] }}>
             {/* NOTE: we may need to introduce a context bridge at some point if we need to use

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,13 +16,10 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGear } from "@fortawesome/free-solid-svg-icons";
 import SettingsDialog from "./components/SettingsDialog";
 import Overlay from "./components/Overlay";
+import CarryTracker from "./components/CarryTracker";
 
 export default function App() {
-  const ballPosition = useBallPosition();
   const theme = useTheme();
-  const { storageToDisplayUnit, formatDisplayValue } = useUnitHelper(
-    MeasurementTypes.Distance
-  );
 
   const [showSettings, setShowSettings] = React.useState(false);
 
@@ -35,21 +32,7 @@ export default function App() {
       <Box id="rootContainer" h="100%" w="100%" bg="black">
         <Overlay
           topLeft={<LaunchControls />}
-          topCenter={
-            <Box
-              p="xs"
-              sx={(theme) =>
-                stylesWithThemedBackgroundColor(theme, {
-                  textAlign: "center",
-                  minWidth: "7rem",
-                })
-              }
-            >
-              <Text>
-                {formatDisplayValue(storageToDisplayUnit(ballPosition.x))}
-              </Text>
-            </Box>
-          }
+          topCenter={<CarryTracker />}
           topRight={
             <Box
               display="flex"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ import { stylesWithThemedBackgroundColor } from "./utils/styles";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGear } from "@fortawesome/free-solid-svg-icons";
 import SettingsDialog from "./components/SettingsDialog";
+import Overlay from "./components/Overlay";
 
 export default function App() {
   const ballPosition = useBallPosition();
@@ -31,59 +32,62 @@ export default function App() {
       withGlobalStyles
       withNormalizeCSS
     >
-      <Box h="100%" w="100%" bg="black" tabIndex={0}>
-        <Box pos="absolute" mt="xs" ml="xs" sx={{ zIndex: 10 }}>
-          <LaunchControls />
-          <Box
-            mt="xs"
-            p="xs"
-            sx={(theme) => stylesWithThemedBackgroundColor(theme)}
-          >
-            <Text>
-              {formatDisplayValue(storageToDisplayUnit(ballPosition.x))}
-            </Text>
-          </Box>
-        </Box>
-        <Box
-          pos="absolute"
-          display="flex"
-          top={0}
-          right={0}
-          mt="xs"
-          mr="xs"
-          sx={{
-            flexDirection: "column",
-            alignItems: "flex-end",
-            zIndex: 10,
-          }}
+      <Box id="rootContainer" h="100%" w="100%" bg="black">
+        <Overlay
+          topLeft={<LaunchControls />}
+          topCenter={
+            <Box
+              p="xs"
+              sx={(theme) =>
+                stylesWithThemedBackgroundColor(theme, {
+                  textAlign: "center",
+                  minWidth: "7rem",
+                })
+              }
+            >
+              <Text>
+                {formatDisplayValue(storageToDisplayUnit(ballPosition.x))}
+              </Text>
+            </Box>
+          }
+          topRight={
+            <Box
+              display="flex"
+              sx={{
+                flexDirection: "column",
+                alignItems: "flex-end",
+              }}
+            >
+              <ActionIcon
+                variant="transparent"
+                color="blue.4"
+                onClick={() => setShowSettings(!showSettings)}
+              >
+                <FontAwesomeIcon icon={faGear} />
+              </ActionIcon>
+              {showSettings && (
+                <SettingsDialog onClose={() => setShowSettings(false)} />
+              )}
+            </Box>
+          }
         >
-          <ActionIcon
-            variant="transparent"
-            color="blue.4"
-            onClick={() => setShowSettings(true)}
-          >
-            <FontAwesomeIcon icon={faGear} />
-          </ActionIcon>
-          {showSettings && (
-            <SettingsDialog onClose={() => setShowSettings(false)} />
-          )}
-        </Box>
-        <Canvas camera={{ position: [0, 0, 50] }}>
-          {/* NOTE: we may need to introduce a context bridge at some point if we need to use
+          <Canvas camera={{ position: [0, 0, 50] }}>
+            {/* NOTE: we may need to introduce a context bridge at some point if we need to use
           information from the matinine context INSIDE of the canvas. We don't have this need
           just yet. See here for more info: 
           https://standard.ai/blog/introducing-standard-view-and-react-three-fiber-context-bridge/ */}
-          <primitive object={new THREE.AxesHelper(10)} />
-          <primitive
-            object={new THREE.GridHelper(100)}
-            rotation={[Math.PI / 2, 0, 0]}
-          />
-          <GolfBall />
-          <PhysicsTicker />
-          <color attach="background" args={["black"]} />
-          <ambientLight />
-          <pointLight position={[10, 10, 10]} />
-        </Canvas>
+            <primitive object={new THREE.AxesHelper(10)} />
+            <primitive
+              object={new THREE.GridHelper(100)}
+              rotation={[Math.PI / 2, 0, 0]}
+            />
+            <GolfBall />
+            <PhysicsTicker />
+            <color attach="background" args={["black"]} />
+            <ambientLight />
+            <pointLight position={[10, 10, 10]} />
+          </Canvas>
+        </Overlay>
       </Box>
     </MantineProvider>
   );

--- a/client/src/components/CarryTracker.tsx
+++ b/client/src/components/CarryTracker.tsx
@@ -1,0 +1,27 @@
+import { Box, Text } from "@mantine/core";
+import React from "react";
+import useUnitHelper from "../hooks/useUnitHelper";
+import { useBallPosition } from "../stores/SimulationStore";
+import { stylesWithThemedBackgroundColor } from "../utils/styles";
+import { MeasurementTypes } from "../utils/units";
+
+export default function CarryTracker() {
+  const ballPosition = useBallPosition();
+  const { storageToDisplayUnit, formatDisplayValue } = useUnitHelper(
+    MeasurementTypes.Distance
+  );
+
+  return (
+    <Box
+      p="xs"
+      sx={(theme) =>
+        stylesWithThemedBackgroundColor(theme, {
+          textAlign: "center",
+          minWidth: "7rem",
+        })
+      }
+    >
+      <Text>{formatDisplayValue(storageToDisplayUnit(ballPosition.x))}</Text>
+    </Box>
+  );
+}

--- a/client/src/components/Overlay.tsx
+++ b/client/src/components/Overlay.tsx
@@ -1,0 +1,68 @@
+import { Box } from "@mantine/core";
+import React from "react";
+
+interface OverlayProps {
+  topLeft?: JSX.Element;
+  topCenter?: JSX.Element;
+  topRight?: JSX.Element;
+  bottomLeft?: JSX.Element;
+  bottomCenter?: JSX.Element;
+  bottomRight?: JSX.Element;
+}
+
+export default function Overlay({
+  topLeft,
+  topCenter,
+  topRight,
+  bottomLeft,
+  bottomCenter,
+  bottomRight,
+  children,
+}: React.PropsWithChildren<OverlayProps>) {
+  return (
+    <Box pos="relative" h="100%" w="100%">
+      <Box
+        id="container"
+        pos="absolute"
+        h="100%"
+        w="100%"
+        p="xs"
+        sx={{ zIndex: 10 }}
+      >
+        <Box id="overlay" pos="relative" h="100%" w="100%">
+          <Box id="topLeft" pos="absolute" top={0} left={0}>
+            {topLeft ?? null}
+          </Box>
+          <Box
+            id="topCenter"
+            pos="absolute"
+            top={0}
+            left="50%"
+            sx={{ translate: "-50%" }}
+          >
+            {topCenter ?? null}
+          </Box>
+          <Box id="topRight" pos="absolute" top={0} right={0}>
+            {topRight ?? null}
+          </Box>
+          <Box id="bottomLeft" pos="absolute" bottom={0} left={0}>
+            {bottomLeft ?? null}
+          </Box>
+          <Box
+            id="bottomCenter"
+            pos="absolute"
+            bottom={0}
+            left="50%"
+            sx={{ translate: "-50%" }}
+          >
+            {bottomCenter ?? null}
+          </Box>
+          <Box id="bottomRight" pos="absolute" bottom={0} right={0}>
+            {bottomRight ?? null}
+          </Box>
+        </Box>
+      </Box>
+      {children}
+    </Box>
+  );
+}

--- a/client/src/components/SettingsControls.tsx
+++ b/client/src/components/SettingsControls.tsx
@@ -1,12 +1,13 @@
-import { Container, SegmentedControl, Select } from "@mantine/core";
-import useClickOutside from "../hooks/useOutsideClick";
+import React from "react";
+import { faGear } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { ActionIcon, Popover, SegmentedControl, Select } from "@mantine/core";
 import {
   usePreferencesActions,
   useTheme,
   useUnitPreferences,
 } from "../stores/PreferencesStore";
 import { ThemeType } from "../utils/preferences";
-import { stylesWithThemedBackgroundColor } from "../utils/styles";
 import {
   MeasurementTypes,
   DistanceUnits,
@@ -14,25 +15,35 @@ import {
   AngleUnits,
 } from "../utils/units";
 
-interface SettingsDialogProps {
-  onClose?: () => void;
+export default function SettingsControls() {
+  const [showSettings, setShowSettings] = React.useState(false);
+
+  return (
+    <Popover opened={showSettings} withArrow onChange={setShowSettings}>
+      <Popover.Target>
+        <ActionIcon
+          variant="transparent"
+          color="blue.4"
+          onClick={() => setShowSettings(!showSettings)}
+        >
+          <FontAwesomeIcon icon={faGear} />
+        </ActionIcon>
+      </Popover.Target>
+      <Popover.Dropdown>
+        <SettingsDialog />
+      </Popover.Dropdown>
+    </Popover>
+  );
 }
 
-export default function SettingsDialog({ onClose }: SettingsDialogProps) {
+function SettingsDialog() {
   const theme = useTheme();
   const unitPreferences = useUnitPreferences();
 
   const { updateUnitPreferences, updateTheme } = usePreferencesActions();
 
-  const register = useClickOutside(() => onClose?.());
-
   return (
-    <Container
-      mt="xs"
-      p="xs"
-      sx={(theme) => stylesWithThemedBackgroundColor(theme)}
-      {...register("settingsContainer")}
-    >
+    <>
       <SegmentedControl
         value={theme}
         data={[
@@ -51,7 +62,6 @@ export default function SettingsDialog({ onClose }: SettingsDialogProps) {
           })
         }
         data={Object.values(DistanceUnits)}
-        {...register("distanceUnitSelect")}
       />
       <Select
         label="Speed:"
@@ -63,7 +73,6 @@ export default function SettingsDialog({ onClose }: SettingsDialogProps) {
           })
         }
         data={Object.values(SpeedUnits)}
-        {...register("speedUnitSelect")}
       />
       <Select
         label="Angle:"
@@ -75,8 +84,7 @@ export default function SettingsDialog({ onClose }: SettingsDialogProps) {
           })
         }
         data={Object.values(AngleUnits)}
-        {...register("angleUnitSelect")}
       />
-    </Container>
+    </>
   );
 }


### PR DESCRIPTION
Moved carry distance display to top center of screen:
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/26262410/212754255-c653c92c-6c27-42bf-8b6b-47e703edff8b.png">

Other cleanup:
- created `Overlay` component to render content in specific spots on top of scene
- created `CarryTracker` component to display current carry distance
- switched to using mantine `Popover` component for handling the display of the settings dialog